### PR TITLE
Fix integration tests for Warning status and add fail_on=warnings test

### DIFF
--- a/.github/scripts/validate-appinspect.sh
+++ b/.github/scripts/validate-appinspect.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # Validate app-inspect results
 # Usage: validate-appinspect.sh <app_inspect_status> <expected_result> <app_id> <version> <build_number>
+#   expected_result: "pass" (Passed or Warning), "fail" (Failure/Error), "passed_only" (strict Passed)
 # Returns: Prints validation results to stderr, exits with 0 on success, 1 on failure
 # Note: All messages go to stderr to avoid polluting stdout
 
 set -e
 
 APP_INSPECT_STATUS="${1:-}"
-EXPECTED_RESULT="${2:-pass}"  # "pass" or "fail"
+EXPECTED_RESULT="${2:-pass}"  # "pass", "fail", or "passed_only"
 APP_ID="${3:-}"
 APP_VERSION="${4:-}"
 APP_BUILD_NUMBER="${5:-}"
@@ -16,18 +17,26 @@ echo "" >&2
 echo "### App-Inspect Status Validation:" >&2
 
 if [ "$EXPECTED_RESULT" == "fail" ]; then
-  # Expecting failure
-  if [ "$APP_INSPECT_STATUS" == "Passed" ]; then
-    echo "❌ Expected app_inspect_status to be 'Failure' or 'Error', but got 'Passed'" >&2
+  # Expecting failure/error — status should not be Passed or Warning
+  if [ "$APP_INSPECT_STATUS" == "Passed" ] || [ "$APP_INSPECT_STATUS" == "Warning" ]; then
+    echo "❌ Expected app_inspect_status to be 'Failure' or 'Error', but got '$APP_INSPECT_STATUS'" >&2
     echo "This failing app should NOT pass inspection!" >&2
     exit 1
   else
     echo "✅ app_inspect_status correctly indicates failure: $APP_INSPECT_STATUS" >&2
   fi
-else
-  # Expecting pass
+elif [ "$EXPECTED_RESULT" == "passed_only" ]; then
+  # Strict: only "Passed" is acceptable
   if [ "$APP_INSPECT_STATUS" != "Passed" ]; then
     echo "❌ Expected app_inspect_status to be 'Passed', but got '$APP_INSPECT_STATUS'" >&2
+    exit 1
+  else
+    echo "✅ app_inspect_status: $APP_INSPECT_STATUS" >&2
+  fi
+else
+  # Default "pass": accept Passed or Warning (non-failing statuses)
+  if [ "$APP_INSPECT_STATUS" != "Passed" ] && [ "$APP_INSPECT_STATUS" != "Warning" ]; then
+    echo "❌ Expected app_inspect_status to be 'Passed' or 'Warning', but got '$APP_INSPECT_STATUS'" >&2
     exit 1
   else
     echo "✅ app_inspect_status: $APP_INSPECT_STATUS" >&2

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -68,7 +68,7 @@ on:
         required: false
         type: string
         default: "pass"
-        description: 'Expected app-inspect result'
+        description: 'Expected app-inspect result: pass (Passed/Warning), fail (Failure/Error), passed_only (strict Passed)'
       continue-on-error:
         required: false
         type: boolean

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -8,7 +8,7 @@ name: Integration Tests
 # ✅ User Defined Commands (SPLUNK_APP_ACTION_n)
 # ✅ Local App-Inspect (local_app_inspect)
 # ✅ Splunkbase API App-Inspect (splunkbase_username/password)
-# ✅ App-Inspect fail_on modes (errors, warnings, none)
+# ✅ App-Inspect fail_on modes (errors, warnings, none) and Warning status handling
 # ✅ Multiple apps in one workflow
 #
 # ⚠️ Not Tested (create PRs or require special access):
@@ -402,7 +402,64 @@ jobs:
       expected-appinspect-result: "fail"
 
 
-  # Test 12: App-inspect with fail_on parameter (none mode)
+  # Test 12: App-inspect with fail_on=warnings (action should fail when warnings exist)
+  test-appinspect-fail-on-warnings:
+    name: Test App-Inspect fail_on=warnings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Run splunk-app-action with fail_on=warnings
+        id: build
+        continue-on-error: true
+        uses: VatsalJagani/splunk-app-action@develop
+        with:
+          app_dir: "tests/integration_test_apps/app_inspect_warn"
+          local_app_inspect: true
+          fail_on: "warnings"
+
+      - name: Validate action failed due to warnings
+        run: |
+          echo "## App-Inspect fail_on=warnings Validation" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          .github/scripts/validate-build-outputs.sh \
+            "app_inspect_warn" \
+            "1.0.0" \
+            "1" \
+            "${{ steps.build.outputs.artifact_name }}" \
+            "${{ steps.build.outputs.app_package_id }}" \
+            "${{ steps.build.outputs.app_version }}" \
+            "${{ steps.build.outputs.app_build_number }}"
+
+          STATUS="${{ steps.build.outputs.app_inspect_status }}"
+          OUTCOME="${{ steps.build.outcome }}"
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### fail_on=warnings Validation:" >> $GITHUB_STEP_SUMMARY
+          echo "- app_inspect_status: $STATUS" >> $GITHUB_STEP_SUMMARY
+          echo "- action outcome: $OUTCOME" >> $GITHUB_STEP_SUMMARY
+
+          # Status should be Warning (warnings present, no errors/failures)
+          if [ "$STATUS" != "Warning" ] && [ "$STATUS" != "Failure" ] && [ "$STATUS" != "Error" ]; then
+            echo "❌ Expected app_inspect_status to be Warning/Failure/Error, got '$STATUS'" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+          echo "✅ app_inspect_status is non-passing: $STATUS" >> $GITHUB_STEP_SUMMARY
+
+          # Action should have failed because fail_on=warnings
+          if [ "$OUTCOME" == "success" ]; then
+            echo "❌ Action should have failed with fail_on=warnings but succeeded" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+          echo "✅ Action correctly failed with fail_on=warnings" >> $GITHUB_STEP_SUMMARY
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "✅ fail_on=warnings mode working correctly!" >> $GITHUB_STEP_SUMMARY
+
+
+  # Test 13: App-inspect with fail_on parameter (none mode)
   test-appinspect-fail-on-none:
     name: Test App-Inspect fail_on=none
     runs-on: ubuntu-latest
@@ -450,7 +507,7 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - test-basic-build
       - test-python-deps
       - test-ucc-build
@@ -462,6 +519,7 @@ jobs:
       - test-splunkbase-appinspect-pass
       - test-splunkbase-appinspect-fail
       - test-local-appinspect-fail
+      - test-appinspect-fail-on-warnings
       - test-appinspect-fail-on-none
     if: always()
     steps:
@@ -483,6 +541,7 @@ jobs:
           echo "- Splunkbase App-Inspect (Pass): ${{ needs.test-splunkbase-appinspect-pass.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Splunkbase App-Inspect (Fail): ${{ needs.test-splunkbase-appinspect-fail.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Local App-Inspect (Fail): ${{ needs.test-local-appinspect-fail.result }}" >> $GITHUB_STEP_SUMMARY
+          echo "- App-Inspect fail_on=warnings: ${{ needs.test-appinspect-fail-on-warnings.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- App-Inspect fail_on=none: ${{ needs.test-appinspect-fail-on-none.result }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
@@ -498,6 +557,7 @@ jobs:
              [ "${{ needs.test-splunkbase-appinspect-pass.result }}" != "success" ] || \
              [ "${{ needs.test-splunkbase-appinspect-fail.result }}" != "success" ] || \
              [ "${{ needs.test-local-appinspect-fail.result }}" != "success" ] || \
+             [ "${{ needs.test-appinspect-fail-on-warnings.result }}" != "success" ] || \
              [ "${{ needs.test-appinspect-fail-on-none.result }}" != "success" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "❌ Some tests failed!" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed `devtools/lint.py` DOC_PATHS to use correct `devtools/` prefix.
 * Removed redundant CI steps, added concurrency group, reduced `fetch-depth`.
 * Added ~24 new unit tests covering previously untested modules.
+* Fixed integration test validation to accept "Warning" as a non-failing status alongside "Passed".
+* Added `fail_on=warnings` integration test to verify action fails when warnings are present.
 
 
 ## [v5](https://github.com/VatsalJagani/splunk-app-action/releases/tag/v5.0.0) - 2025-11-19

--- a/tests/integration_test_apps/app_inspect_warn/README.md
+++ b/tests/integration_test_apps/app_inspect_warn/README.md
@@ -1,0 +1,9 @@
+# Valid Test App (App-Inspect)
+
+This is a valid Splunk app used for testing the splunk-app-action GitHub Action with local app-inspect.
+
+## Purpose
+This app should pass all app-inspect checks and be used to test:
+- Local app-inspect validation
+- Successful app-inspect validation
+- App-inspect report generation

--- a/tests/integration_test_apps/app_inspect_warn/bin/example_script.py
+++ b/tests/integration_test_apps/app_inspect_warn/bin/example_script.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""
+Example script for valid test app
+"""
+
+def main():
+    print("This is a valid test app script")
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration_test_apps/app_inspect_warn/default/app.conf
+++ b/tests/integration_test_apps/app_inspect_warn/default/app.conf
@@ -1,0 +1,15 @@
+[install]
+is_configured = 0
+
+[ui]
+is_visible = 1
+label = Warning Test App (App-Inspect fail_on=warnings)
+
+[launcher]
+author = Test Author
+description = A Splunk app that produces warnings for testing fail_on=warnings mode
+version = 1.0.0
+
+[package]
+id = app_inspect_warn
+check_for_updates = 1


### PR DESCRIPTION
validate-appinspect.sh now accepts both "Passed" and "Warning" as non-failing statuses, fixing tests that broke when AppInspect started returning "Warning" instead of "Passed" for apps with warnings.

Added fail_on=warnings integration test with dedicated test app.

<!-- To ensure we can review your pull request promptly, please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
-

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the `CONTRIBUTING` docs:
    [Making a pull request](./CONTRIBUTING.md#making-a-pull-request)
- [ ] I've updated or added any relevant docstrings following the syntax described in the `CONTRIBUTING` docs:
    [Writing docstrings](./CONTRIBUTING.md#writing-docstrings)
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
