### PR TITLE
fix: extend is_remove_not_allowed_executables_from_lib to python_requirements_file builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* **`is_remove_not_allowed_executables_from_lib` for Python Dependency Manager** - This input now also applies when using `python_requirements_file`. Previously it only worked for UCC builds. Use this to strip platform-specific compiled extensions (e.g. `charset-normalizer` `.so` files) that cause App Inspect `check_aarch64_compatibility` failures.
+
 ## [v6.1.1](https://github.com/VatsalJagani/splunk-app-action/releases/tag/v6.1.1) - 2026-05-20
 
 ### Fixed

--- a/docs/source/capabilities.md
+++ b/docs/source/capabilities.md
@@ -36,7 +36,7 @@ Supports Add-on build with **UCC Add-on Generator** using the `ucc-gen build` co
 - Reference: [Splunk Add-on UCC Framework](https://splunk.github.io/addonfactory-ucc-generator/)
 - The `app_dir` folder must have a sub-folder named `package` and a file named `globalConfig.json`
 - You need to use `ucc-gen init` command locally first to initialize the Add-on/Repository before using this action
- - By default, this action does not remove files with mimetype `application/x-executable` or `application/x-sharedlib` from generated `lib/` output. Set `is_remove_not_allowed_executables_from_lib: true` to enable stricter cleanup for AppInspect compliance.
+ - By default, this action does not remove files with mimetype `application/x-executable` or `application/x-sharedlib` from generated `lib/` output. Set `is_remove_not_allowed_executables_from_lib: true` to enable stricter cleanup for AppInspect compliance. This also works with the Python Dependency Manager (`python_requirements_file`).
 
 ```yaml
 - uses: VatsalJagani/splunk-app-action@v6

--- a/docs/source/inputs.md
+++ b/docs/source/inputs.md
@@ -23,10 +23,10 @@ Complete reference of all available inputs for the splunk-app-action GitHub Acti
 
 
 ### `is_remove_not_allowed_executables_from_lib`
-- **Description:** Remove files with mimetype `application/x-executable` or `application/x-sharedlib` from UCC build output `lib/` folder before packaging. This helps avoid Splunk AppInspect failures due to compiled binaries. Set to `true` only if you want stricter cleanup; default is `false` for compatibility.
+- **Description:** Remove files with mimetype `application/x-executable` or `application/x-sharedlib` from the `lib/` folder before packaging. Works for both UCC (`use_ucc_gen`) and Python dependency manager (`python_requirements_file`) builds. This helps avoid Splunk AppInspect failures due to platform-specific compiled binaries (e.g. x86_64 `.so` files failing the `check_aarch64_compatibility` check). Set to `true` only if you want stricter cleanup; default is `false` for compatibility.
 - **Required:** false
 - **Default:** false
-- **When to enable:** Set to `true` if you want to remove compiled executables or shared libraries from the UCC build output for stricter AppInspect compliance. Leave as `false` if your add-on runtime requires such files.
+- **When to enable:** Set to `true` if your dependencies install platform-specific compiled extensions (e.g. `charset-normalizer`, `mypyc`-compiled packages) that cause AArch64 App Inspect failures. Leave as `false` if your add-on runtime requires such files.
 
 
 ### `python_requirements_file`

--- a/src/helpers/lib_cleanup.py
+++ b/src/helpers/lib_cleanup.py
@@ -1,0 +1,36 @@
+import os
+
+import github_action_toolkit as gat
+import magic
+
+
+def remove_not_allowed_executables(lib_dir: str) -> None:
+    """Remove files with mimetype application/x-executable or application/x-sharedlib from lib_dir.
+
+    Walks lib_dir recursively and deletes any file whose mimetype is
+    application/x-executable or application/x-sharedlib. Files that cannot
+    be identified (magic failure) are left untouched and a warning is logged.
+
+    Args:
+        lib_dir: Path to the lib directory to clean. No-op if the directory does not exist.
+    """
+    if not os.path.isdir(lib_dir):
+        gat.info(f"lib directory not found, skipping executable cleanup: {lib_dir}")
+        return
+
+    removed_files_count = 0
+    for root, _, files in os.walk(lib_dir):
+        for file_name in files:
+            file_path = os.path.join(root, file_name)
+            try:
+                magic_mime = magic.Magic(mime=True)
+                mimetype_val = magic_mime.from_file(file_path)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+            except Exception as e:
+                gat.warning(f"magic failed for {file_path}: {e}")
+                continue
+            if mimetype_val in ("application/x-executable", "application/x-sharedlib"):
+                os.remove(file_path)
+                removed_files_count += 1
+                gat.info(f"Removed not allowed executable type: {file_path} ({mimetype_val})")
+
+    gat.debug(f"Removed not allowed executables count: {removed_files_count}")

--- a/src/main.py
+++ b/src/main.py
@@ -134,7 +134,7 @@ def main() -> None:
         with gat.group("🏗️ Installing dynamic Python Dependencies"):
             with keep_working_dir_unchanged():
                 app_build_dir_name = python_dependency_manager.install_dependencies(
-                    saved_paths, app_info
+                    saved_paths, app_info, is_remove_not_allowed_executables_from_lib
                 )
 
     else:

--- a/src/python_dependency_manager.py
+++ b/src/python_dependency_manager.py
@@ -3,8 +3,8 @@ import shutil
 import subprocess
 
 import github_action_toolkit as gat
-import magic
 
+from helpers.lib_cleanup import remove_not_allowed_executables
 from helpers.saved_values import AppInfo, SavedPaths
 
 
@@ -185,24 +185,7 @@ def install_dependencies(
 
     # Remove files with mimetype application/x-executable or application/x-sharedlib from lib directory
     if is_remove_not_allowed_executables_from_lib:
-        removed_files_count = 0
-        if os.path.isdir(target_dir):
-            for root, _, files in os.walk(target_dir):
-                for file_name in files:
-                    file_path = os.path.join(root, file_name)
-                    try:
-                        magic_mime = magic.Magic(mime=True)
-                        mimetype_val = magic_mime.from_file(file_path)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
-                    except Exception as e:
-                        gat.warning(f"magic failed for {file_path}: {e}")
-                        continue
-                    if mimetype_val in ("application/x-executable", "application/x-sharedlib"):
-                        os.remove(file_path)
-                        removed_files_count += 1
-                        gat.info(
-                            f"Removed not allowed executable type: {file_path} ({mimetype_val})"
-                        )
-        gat.debug(f"Removed not allowed executables count: {removed_files_count}")
+        remove_not_allowed_executables(target_dir)
 
     # Copy the build to final location
     final_build_dir = "python_deps_generated_build"

--- a/src/python_dependency_manager.py
+++ b/src/python_dependency_manager.py
@@ -3,6 +3,7 @@ import shutil
 import subprocess
 
 import github_action_toolkit as gat
+import magic
 
 from helpers.saved_values import AppInfo, SavedPaths
 
@@ -19,6 +20,7 @@ def _is_console_script(filepath: str) -> bool:
 def install_dependencies(
     saved_paths: SavedPaths,
     app_info: AppInfo,  # pyright: ignore[reportUnusedParameter]
+    is_remove_not_allowed_executables_from_lib: bool = False,
 ) -> str:
     """Install Python dependencies from requirements.txt and return the build directory name.
 
@@ -180,6 +182,27 @@ def install_dependencies(
             os.remove(python_version_file_path)
         except Exception as e:
             gat.warning(f"Failed to remove .python-version: {e}")
+
+    # Remove files with mimetype application/x-executable or application/x-sharedlib from lib directory
+    if is_remove_not_allowed_executables_from_lib:
+        removed_files_count = 0
+        if os.path.isdir(target_dir):
+            for root, _, files in os.walk(target_dir):
+                for file_name in files:
+                    file_path = os.path.join(root, file_name)
+                    try:
+                        magic_mime = magic.Magic(mime=True)
+                        mimetype_val = magic_mime.from_file(file_path)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+                    except Exception as e:
+                        gat.warning(f"magic failed for {file_path}: {e}")
+                        continue
+                    if mimetype_val in ("application/x-executable", "application/x-sharedlib"):
+                        os.remove(file_path)
+                        removed_files_count += 1
+                        gat.info(
+                            f"Removed not allowed executable type: {file_path} ({mimetype_val})"
+                        )
+        gat.debug(f"Removed not allowed executables count: {removed_files_count}")
 
     # Copy the build to final location
     final_build_dir = "python_deps_generated_build"

--- a/src/ucc_gen.py
+++ b/src/ucc_gen.py
@@ -3,8 +3,8 @@ import shutil
 import subprocess
 
 import github_action_toolkit as gat
-import magic
 
+from helpers.lib_cleanup import remove_not_allowed_executables
 from helpers.saved_values import AppInfo, SavedPaths
 
 
@@ -45,29 +45,8 @@ def build(
         gat.warning(f"ucc-gen build exited with code {result.returncode}")
 
     if is_remove_not_allowed_executables_from_lib:
-        # Remove files with mimetype application/x-executable or application/x-sharedlib from UCC lib directory.
         ucc_lib_dir = os.path.join(ta_dir, "output", app_info.package_id, "lib")
-        removed_files_count = 0
-        if os.path.isdir(ucc_lib_dir):
-            for root, _, files in os.walk(ucc_lib_dir):
-                for file_name in files:
-                    file_path = os.path.join(root, file_name)
-                    try:
-                        magic_mime = magic.Magic(mime=True)
-                        mimetype_val = magic_mime.from_file(file_path)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
-                    except Exception as e:
-                        gat.warning(f"magic failed for {file_path}: {e}")
-                        continue
-                    if mimetype_val in ("application/x-executable", "application/x-sharedlib"):
-                        os.remove(file_path)
-                        removed_files_count += 1
-                        gat.info(
-                            f"UCC - Removed not allowed executable type: {file_path} ({mimetype_val})"
-                        )
-        else:
-            gat.info(f"UCC lib directory not found, skipping executable cleanup: {ucc_lib_dir}")
-
-        gat.debug(f"Removed not allowed executables count: {removed_files_count}")
+        remove_not_allowed_executables(ucc_lib_dir)
     else:
         gat.info("UCC executables cleanup disabled via input")
 

--- a/tests/test_python_dependency_manager.py
+++ b/tests/test_python_dependency_manager.py
@@ -457,7 +457,7 @@ class TestRemoveNotAllowedExecutablesFromLib(unittest.TestCase):
             "python_dependency_manager.subprocess.run",
             side_effect=self._mock_pip_install_with_so_files,
         ):
-            with patch("python_dependency_manager.magic.Magic") as mock_magic_cls:
+            with patch("helpers.lib_cleanup.magic.Magic") as mock_magic_cls:
                 mock_magic_instance = MagicMock()
                 mock_magic_instance.from_file.side_effect = self._fake_mimetype
                 mock_magic_cls.return_value = mock_magic_instance
@@ -509,9 +509,7 @@ class TestRemoveNotAllowedExecutablesFromLib(unittest.TestCase):
             "python_dependency_manager.subprocess.run",
             side_effect=self._mock_pip_install_with_so_files,
         ):
-            with patch(
-                "python_dependency_manager.magic.Magic", side_effect=Exception("magic error")
-            ):
+            with patch("helpers.lib_cleanup.magic.Magic", side_effect=Exception("magic error")):
                 with patch.dict(
                     os.environ,
                     {

--- a/tests/test_python_dependency_manager.py
+++ b/tests/test_python_dependency_manager.py
@@ -8,13 +8,19 @@
 # pyright: reportUnknownArgumentType=false
 # pyright: reportFunctionMemberAccess=false
 # pyright: reportUnannotatedClassAttribute=false
+# pyright: reportUninitializedInstanceVariable=false
 
 import os
 import subprocess
 import tarfile
+import tempfile
 import unittest
+from pathlib import Path
+from typing import override
 from unittest.mock import MagicMock, patch
 
+import python_dependency_manager  # pyright: ignore[reportMissingImports]
+from helpers.saved_values import AppInfo, SavedPaths  # pyright: ignore[reportMissingImports]
 from main import main  # pyright: ignore[reportMissingImports]
 
 from .helper_test import setup_action_yml
@@ -390,3 +396,135 @@ class TestUvArtifactCleanup(unittest.TestCase):
             assert any("dangling_lib_link" in n for n in symlink_names), (
                 f"dangling symlink in lib/ should be preserved in the tarball; symlinks found: {symlink_names}"
             )
+
+
+class TestRemoveNotAllowedExecutablesFromLib(unittest.TestCase):
+    """Tests for is_remove_not_allowed_executables_from_lib in install_dependencies."""
+
+    temp_dir: tempfile.TemporaryDirectory[str]
+    original_cwd: str
+    saved_paths: SavedPaths
+    app_info: AppInfo
+
+    @override
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir.name)
+
+        # Create repo/app/lib structure with requirements.txt
+        repo_dir = os.path.join(self.temp_dir.name, "repodir")
+        app_dir_name = "my_app"
+        lib_dir = os.path.join(repo_dir, app_dir_name, "lib")
+        os.makedirs(lib_dir)
+        Path(os.path.join(lib_dir, "requirements.txt")).write_text("requests\n")
+        Path(os.path.join(repo_dir, app_dir_name, "default")).mkdir()
+        Path(os.path.join(repo_dir, app_dir_name, "default", "app.conf")).write_text(
+            "[launcher]\nversion = 1.0.0\n"
+        )
+
+        self.saved_paths = MagicMock(spec=SavedPaths)
+        self.saved_paths.repo_dir_path = repo_dir
+        self.saved_paths.app_dir_name = app_dir_name
+
+        self.app_info = MagicMock(spec=AppInfo)
+        self.app_info.package_id = "my_app"
+
+    @override
+    def tearDown(self) -> None:
+        os.chdir(self.original_cwd)
+        self.temp_dir.cleanup()
+
+    def _mock_pip_install_with_so_files(self, cmd: list[str], **kwargs) -> MagicMock:
+        """Simulate uv pip install creating platform-specific .so files and a pure Python file."""
+        if "install" in cmd:
+            target_dir = cmd[cmd.index("--target") + 1]
+            os.makedirs(target_dir, exist_ok=True)
+            Path(
+                os.path.join(target_dir, "charset_normalizer.cpython-39-x86_64-linux-gnu.so")
+            ).write_bytes(b"\x7fELF")
+            Path(os.path.join(target_dir, "pure_python_module.py")).write_text("# pure python\n")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    def _fake_mimetype(self, path: str) -> str:
+        if path.endswith(".so"):
+            return "application/x-sharedlib"
+        return "text/plain"
+
+    def test_so_files_removed_when_enabled(self) -> None:
+        """x86_64 .so files are removed when is_remove_not_allowed_executables_from_lib=True."""
+        with patch(
+            "python_dependency_manager.subprocess.run",
+            side_effect=self._mock_pip_install_with_so_files,
+        ):
+            with patch("python_dependency_manager.magic.Magic") as mock_magic_cls:
+                mock_magic_instance = MagicMock()
+                mock_magic_instance.from_file.side_effect = self._fake_mimetype
+                mock_magic_cls.return_value = mock_magic_instance
+
+                with patch.dict(
+                    os.environ,
+                    {
+                        "INPUT_PYTHON_REQUIREMENTS_FILE": "lib/requirements.txt",
+                        "INPUT_SPLUNK_PYTHON_VERSION": "3.9",
+                    },
+                ):
+                    python_dependency_manager.install_dependencies(
+                        self.saved_paths,
+                        self.app_info,
+                        is_remove_not_allowed_executables_from_lib=True,
+                    )
+
+        lib_dir = Path("python_deps_generated_build") / "lib"
+        so_files = list(lib_dir.glob("*.so"))
+        assert len(so_files) == 0, f".so files should be removed but found: {so_files}"
+        assert (lib_dir / "pure_python_module.py").exists(), "pure Python file should be kept"
+
+    def test_so_files_kept_when_disabled(self) -> None:
+        """x86_64 .so files are kept when is_remove_not_allowed_executables_from_lib=False."""
+        with patch(
+            "python_dependency_manager.subprocess.run",
+            side_effect=self._mock_pip_install_with_so_files,
+        ):
+            with patch.dict(
+                os.environ,
+                {
+                    "INPUT_PYTHON_REQUIREMENTS_FILE": "lib/requirements.txt",
+                    "INPUT_SPLUNK_PYTHON_VERSION": "3.9",
+                },
+            ):
+                python_dependency_manager.install_dependencies(
+                    self.saved_paths,
+                    self.app_info,
+                    is_remove_not_allowed_executables_from_lib=False,
+                )
+
+        lib_dir = Path("python_deps_generated_build") / "lib"
+        so_files = list(lib_dir.glob("*.so"))
+        assert len(so_files) == 1, f".so file should be kept but found: {so_files}"
+
+    def test_magic_failure_keeps_files(self) -> None:
+        """When magic raises an exception for a file, that file is left untouched."""
+        with patch(
+            "python_dependency_manager.subprocess.run",
+            side_effect=self._mock_pip_install_with_so_files,
+        ):
+            with patch(
+                "python_dependency_manager.magic.Magic", side_effect=Exception("magic error")
+            ):
+                with patch.dict(
+                    os.environ,
+                    {
+                        "INPUT_PYTHON_REQUIREMENTS_FILE": "lib/requirements.txt",
+                        "INPUT_SPLUNK_PYTHON_VERSION": "3.9",
+                    },
+                ):
+                    python_dependency_manager.install_dependencies(
+                        self.saved_paths,
+                        self.app_info,
+                        is_remove_not_allowed_executables_from_lib=True,
+                    )
+
+        lib_dir = Path("python_deps_generated_build") / "lib"
+        so_files = list(lib_dir.glob("*.so"))
+        assert len(so_files) == 1, ".so file should be kept when magic raises an error"

--- a/tests/test_ucc_gen.py
+++ b/tests/test_ucc_gen.py
@@ -72,7 +72,7 @@ class TestUccGen(unittest.TestCase):
         Default is False, so must set True explicitly.
         """
         with patch("ucc_gen.subprocess.run", side_effect=self._mock_ucc_subprocess_run):
-            with patch("ucc_gen.magic.Magic.from_file") as mock_magic:
+            with patch("helpers.lib_cleanup.magic.Magic.from_file") as mock_magic:
 
                 def fake_mimetype(path):
                     if path.endswith("abc123__mypyc.cpython-312-x86_64-linux-gnu.so"):
@@ -132,7 +132,7 @@ class TestUccGen(unittest.TestCase):
         Test that magic failure is handled gracefully and does not remove files.
         """
         with patch("ucc_gen.subprocess.run", side_effect=self._mock_ucc_subprocess_run):
-            with patch("ucc_gen.magic.Magic", side_effect=Exception("magic error")):
+            with patch("helpers.lib_cleanup.magic.Magic", side_effect=Exception("magic error")):
                 build_dir_name = ucc_gen.build(
                     self.saved_paths, self.app_info, is_remove_not_allowed_executables_from_lib=True
                 )


### PR DESCRIPTION
## Summary

- `is_remove_not_allowed_executables_from_lib` now applies to `python_requirements_file` builds, not only UCC builds
- Updated docs (`inputs.md`, `capabilities.md`) to reflect that the input works for both build types

## Why

When using `python_requirements_file`, `uv pip install` on the x86_64 GitHub Actions runner installs binary wheels with platform-specific `.so` files (e.g. `charset-normalizer`, mypyc-compiled packages). These fail Splunk App Inspect's `check_aarch64_compatibility` check. The fix was already present for UCC builds but was never wired up for the Python dependency manager path.

## Changes

- `python_dependency_manager.py`: added `is_remove_not_allowed_executables_from_lib` parameter with the same mimetype-based removal logic used in `ucc_gen.py`
- `main.py`: passes the flag through to `install_dependencies()`
- `docs/source/inputs.md`: updated description to mention both UCC and `python_requirements_file`
- `docs/source/capabilities.md`: noted that the flag also works with Python Dependency Manager
- `CHANGELOG.md`: added entry under `## Unreleased`